### PR TITLE
Disable DCC simulation

### DIFF
--- a/1.8/entrypoint.sh
+++ b/1.8/entrypoint.sh
@@ -126,6 +126,6 @@ EOS
     rm $PID;
   fi
 
-  exec ./eggdrop -nt -m ${CONFIG}
+  exec ./eggdrop -n -m ${CONFIG}
 fi
 exec "$@"


### PR DESCRIPTION
Running Docker in a detached mode with the current entry point causes Eggdrop to die with [`END OF FILE ON TERMINAL`](https://github.com/eggheads/eggdrop/blob/release/1.8.2/src/main.c#L888). This makes it difficult to use the container in environments where they can be automatically updated.