### PR TITLE
Use latest versions of config.guess and config.sub

### DIFF
--- a/1.8/Dockerfile
+++ b/1.8/Dockerfile
@@ -15,6 +15,9 @@ RUN apk add --no-cache --virtual egg-deps tcl-dev wget ca-certificates make tar 
   && rm eggdrop-1.8.3.tar.gz.asc \
   && tar -zxvf eggdrop-1.8.3.tar.gz \
   && rm eggdrop-1.8.3.tar.gz \
+  && wget http://git.savannah.gnu.org/cgit/config.git/plain/config.guess \
+  && wget http://git.savannah.gnu.org/cgit/config.git/plain/config.sub \
+  && mv config.guess config.sub eggdrop-1.8.3/misc \
   && ( cd eggdrop-1.8.3 \
     && ./configure \
     && make config \

--- a/1.8/Dockerfile
+++ b/1.8/Dockerfile
@@ -10,7 +10,10 @@ RUN apk add --no-cache tcl bash openssl
 RUN apk add --no-cache --virtual egg-deps tcl-dev wget ca-certificates make tar gpgme build-base openssl-dev \
   && wget ftp://ftp.eggheads.org/pub/eggdrop/source/1.8/eggdrop-1.8.3.tar.gz \
   && wget ftp://ftp.eggheads.org/pub/eggdrop/source/1.8/eggdrop-1.8.3.tar.gz.asc \
-  && gpg --keyserver ha.pool.sks-keyservers.net --recv-key E01C240484DE7DBE190FE141E7667DE1D1A39AFF \
+  && ( gpg --keyserver Zpool.sks-keyservers.net --recv-keys E01C240484DE7DBE190FE141E7667DE1D1A39AFF \
+    || gpg --keyserver pgp.mit.edu --recv-keys E01C240484DE7DBE190FE141E7667DE1D1A39AFF \
+    || gpg --keyserver ha.pool.sks-keyservers.net --recv-keys E01C240484DE7DBE190FE141E7667DE1D1A39AFF \
+    || gpg --keyserver keyserver.pgp.com --recv-keys E01C240484DE7DBE190FE141E7667DE1D1A39AFF ) \
   && gpg --batch --verify eggdrop-1.8.3.tar.gz.asc eggdrop-1.8.3.tar.gz \
   && rm eggdrop-1.8.3.tar.gz.asc \
   && tar -zxvf eggdrop-1.8.3.tar.gz \


### PR DESCRIPTION
They have the most up-to-date features and support a greater number of devices.

Signed-off-by: Lee Jones <lee.jones@linaro.org>