### PR TITLE
Add PKG_ADDITIONAL

### DIFF
--- a/develop/Dockerfile
+++ b/develop/Dockerfile
@@ -8,8 +8,9 @@ RUN apk add --no-cache 'su-exec>=0.2'
 
 ENV EGGDROP_SHA256 f977f8f586d1b65d2bae581b5b5828d79193a29a217f617c4c74d1868a566c7f
 ENV EGGDROP_COMMIT 886c2ff6f943952018000c16cb48c08b8ab99127
+ARG PKG_ADDITIONAL=""
 
-RUN apk --update add --no-cache tcl bash openssl
+RUN apk --update add --no-cache tcl bash openssl ${PKG_ADDITIONAL}
 RUN apk --update add --no-cache --virtual egg-deps tcl-dev wget ca-certificates make tar gpgme build-base openssl-dev \
   && wget "https://github.com/eggheads/eggdrop/archive/$EGGDROP_COMMIT.tar.gz" -O develop.tar.gz \
   && echo "$EGGDROP_SHA256  develop.tar.gz" | sha256sum -c - \


### PR DESCRIPTION
I read them on the github. The question of adding packages comes back. Your concern seems to be to keep the basic image light. You don't want to add any additional default packages. It's just. you have to install what is strictly necessary.
On the other hand, nothing prevents during the docker build from having an ARG with a customizable extra package list. So those who want packages can simply define before the build without burdening the original dockerfile.

add an package :
`docker build --build-arg PKG_ADDITIONAL=tcl-tls`
in docker-compose 
```
version: "3.9"
services:
  eggdrop
    build: 
      args:
        - PKG_ADDITIONAL=tcl-tls
```