### PR TITLE
Use https to fetch eggdrop tarball & signature file

### DIFF
--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -8,8 +8,8 @@ RUN apk add --no-cache 'su-exec>=0.2'
 
 RUN apk add --no-cache tcl bash
 RUN apk add --no-cache --virtual egg-deps tcl-dev wget make tar gpgme build-base \
-  && wget ftp://ftp.eggheads.org/pub/eggdrop/source/1.6/eggdrop1.6.21.tar.gz \
-  && wget ftp://ftp.eggheads.org/pub/eggdrop/source/1.6/eggdrop1.6.21.tar.gz.asc \
+  && wget https://ftp.eggheads.org/pub/eggdrop/source/1.6/eggdrop1.6.21.tar.gz \
+  && wget https://ftp.eggheads.org/pub/eggdrop/source/1.6/eggdrop1.6.21.tar.gz.asc \
   && gpg --keyserver ha.pool.sks-keyservers.net --recv-key B0B3D92ABE1D20233A2ECB01DB909F5EE7C0E7F7 \
   && gpg --batch --verify eggdrop1.6.21.tar.gz.asc eggdrop1.6.21.tar.gz \
   && rm eggdrop1.6.21.tar.gz.asc \

--- a/1.8/Dockerfile
+++ b/1.8/Dockerfile
@@ -8,8 +8,8 @@ RUN apk add --no-cache 'su-exec>=0.2'
 
 RUN apk add --no-cache tcl bash openssl
 RUN apk add --no-cache --virtual egg-deps tcl-dev wget ca-certificates make tar gpgme build-base openssl-dev \
-  && wget ftp://ftp.eggheads.org/pub/eggdrop/source/1.8/eggdrop-1.8.4.tar.gz \
-  && wget ftp://ftp.eggheads.org/pub/eggdrop/source/1.8/eggdrop-1.8.4.tar.gz.asc \
+  && wget https://ftp.eggheads.org/pub/eggdrop/source/1.8/eggdrop-1.8.4.tar.gz \
+  && wget https://ftp.eggheads.org/pub/eggdrop/source/1.8/eggdrop-1.8.4.tar.gz.asc \
   && gpg --keyserver ha.pool.sks-keyservers.net --recv-key E01C240484DE7DBE190FE141E7667DE1D1A39AFF \
   && gpg --batch --verify eggdrop-1.8.4.tar.gz.asc eggdrop-1.8.4.tar.gz \
   && command -v gpgconf > /dev/null \

--- a/1.9-libs/Dockerfile
+++ b/1.9-libs/Dockerfile
@@ -9,8 +9,8 @@ RUN apk add --no-cache 'su-exec>=0.2'
 RUN apk add --no-cache tcl bash openssl sqlite-tcl mariadb-connector-c-dev tcl-tls \
   && apk add --no-cache tcl-lib --update-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ --allow-untrusted \
   && apk add --no-cache --virtual egg-deps tcl-dev wget ca-certificates make tar gpgme build-base openssl-dev \
-  && wget ftp://ftp.eggheads.org/pub/eggdrop/source/1.9/eggdrop-1.9.1.tar.gz \
-  && wget ftp://ftp.eggheads.org/pub/eggdrop/source/1.9/eggdrop-1.9.1.tar.gz.asc \
+  && wget https://ftp.eggheads.org/pub/eggdrop/source/1.9/eggdrop-1.9.1.tar.gz \
+  && wget https://ftp.eggheads.org/pub/eggdrop/source/1.9/eggdrop-1.9.1.tar.gz.asc \
   && gpg --keyserver keyserver.ubuntu.com --recv-key E01C240484DE7DBE190FE141E7667DE1D1A39AFF \
   && gpg --batch --verify eggdrop-1.9.1.tar.gz.asc eggdrop-1.9.1.tar.gz \
   && command -v gpgconf > /dev/null \

--- a/1.9/Dockerfile
+++ b/1.9/Dockerfile
@@ -8,8 +8,8 @@ RUN apk add --no-cache 'su-exec>=0.2'
 
 RUN apk add --no-cache tcl bash openssl
 RUN apk add --no-cache --virtual egg-deps tcl-dev wget ca-certificates make tar gpgme build-base openssl-dev \
-  && wget ftp://ftp.eggheads.org/pub/eggdrop/source/1.9/eggdrop-1.9.1.tar.gz \
-  && wget ftp://ftp.eggheads.org/pub/eggdrop/source/1.9/eggdrop-1.9.1.tar.gz.asc \
+  && wget https://ftp.eggheads.org/pub/eggdrop/source/1.9/eggdrop-1.9.1.tar.gz \
+  && wget https://ftp.eggheads.org/pub/eggdrop/source/1.9/eggdrop-1.9.1.tar.gz.asc \
   && gpg --keyserver keyserver.ubuntu.com --recv-key E01C240484DE7DBE190FE141E7667DE1D1A39AFF \
   && gpg --batch --verify eggdrop-1.9.1.tar.gz.asc eggdrop-1.9.1.tar.gz \
   && command -v gpgconf > /dev/null \


### PR DESCRIPTION
ftp is not safe at all for a long time, https is better.